### PR TITLE
Updated README with improved instructions and usage examples for `vau…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,88 @@ The specific use case I am working on is to change database connection strings f
 ## Running the script
 Best option is to install [uv](https://docs.astral.sh/uv/). After that you can run the script with 
 
-`uv tool vault_search_replace.py`
+`uvx vault_search_replace`
 
-The script has [inline metadata](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies) and will run without installation.
+or 
+
+`uv tool install vault_search_replace`
+
+The package is published on PyPI and all the dependencies are installed automatically.
 
 ## Usage
 
 ```shell
-main.py [OPTIONS] 
-                      STRING_TO_SEARCH 
-                      VAULT_NAMESPACE
-                      VAULT_BASE_URL 
-                      VAULT_ACCESS_TOKEN
-                      [REPLACEMENT_STRING]
+vault-search-replace --help   
+                                                                                                                          
+ Usage: vault-search-replace [OPTIONS] COMMAND [ARGS]...                                                                  
+                                                                                                                          
+ An utility to search and replace Vault secrets.                                                                          
+                                                                                                                          
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --verbose  -v        Enable verbose logging                                                                            │
+│ --help               Show this message and exit.                                                                       │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ search   Search strings in Hashicorp Vault secrets.                                                                    │
+│ replace  Search and replace strings in Hashicorp Vault secrets.                                                        │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+```shell
+vault-search-replace search --help
+Vault Search Replace v0.3.0
+                                                                                                                          
+ Usage: vault-search-replace search [OPTIONS] STRING_TO_SEARCH VAULT_NAMESPACE                                            
+                                    VAULT_BASE_URL VAULT_ACCESS_TOKEN                                                     
+                                                                                                                          
+ Search strings in Hashicorp Vault secrets.                                                                               
+                                                                                                                          
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    string_to_search        TEXT  String to Search [required]                                                         │
+│ *    vault_namespace         TEXT  Vault Namespace [required]                                                          │
+│ *    vault_base_url          TEXT  Vault Base url to Search [required]                                                 │
+│ *    vault_access_token      TEXT  Vault Access Token [required]                                                       │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                            │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+```shell
+vault-search-replace replace --help
+Vault Search Replace v0.3.0
+                                                                                                                          
+ Usage: vault-search-replace replace [OPTIONS] STRING_TO_SEARCH VAULT_NAMESPACE                                           
+                                     VAULT_BASE_URL VAULT_ACCESS_TOKEN                                                    
+                                     [REPLACEMENT_STRING]                                                                 
+                                                                                                                          
+ Search and replace strings in Hashicorp Vault secrets.                                                                   
+                                                                                                                          
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    string_to_search          TEXT  String to Search [required]                                                       │
+│ *    vault_namespace           TEXT  Vault Namespace [required]                                                        │
+│ *    vault_base_url            TEXT  Vault Base url to Search [required]                                               │
+│ *    vault_access_token        TEXT  Vault Access Token [required]                                                     │
+│      [replacement_string]      TEXT  String to Replace                                                                 │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --execute          Apply the changes (default is dry-run)                                                              │
+│ --help             Show this message and exit.                                                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
 ```
 ### Command Line Parameters:
 
-#### Required:
+#### Common to both commands:
 string_to_search
 vault_namespace
 vault_base_url
 vault_access_token
 
-#### Optional
+#### Only for replace
 string_to_replace
 
-#### Options
---no-dry-run - confirm the execution
-
-Without the (optional) replace_string argument, the command will execute a (string) search for _search_string_.
-With the replace argument, the command always creates a new secret version. By default, it performs a dry-run—showing the changes without applying them. To actually apply the changes to the secrets, the **--no-dry-run** option must be passed.
+#### Options - on replace command
+--execute - confirm the execution
 
 As of this release, the search is very simple (python **str.find** function). 


### PR DESCRIPTION
…lt-search-replace` CLI commands.

## Summary by Sourcery

Update README to document the published `vault-search-replace` CLI, its subcommands, and usage.

Documentation:
- Expand README with uv-based installation options for the `vault-search-replace` package.
- Document CLI help output and arguments for the `search` and `replace` commands, including the `--execute` flag and dry-run behavior.